### PR TITLE
Fix MaxActiveVideoStreams limit check to prevent transcoding before v…

### DIFF
--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -755,27 +755,6 @@ namespace Emby.Server.Implementations.Session
                 ? null
                 : GetNowPlayingItem(session, info.ItemId);
 
-            // Check video stream limits before allowing playback
-            if (libraryItem?.MediaType == MediaType.Video)
-            {
-                var sessionUsers = GetUsers(session);
-                foreach (var user in sessionUsers)
-                {
-                    if (user.MaxActiveVideoStreams > 0)
-                    {
-                        var activeVideoStreams = Sessions.Count(s =>
-                            s.UserId.Equals(user.Id) &&
-                            s.NowPlayingItem?.MediaType == MediaType.Video);
-
-                        _logger.LogInformation("Current/Max video streams for user {User}: {VideoStreams}/{MaxVideoStreams}", user.Username, activeVideoStreams, user.MaxActiveVideoStreams);
-                        if (activeVideoStreams >= user.MaxActiveVideoStreams)
-                        {
-                            throw new MediaBrowser.Controller.Net.SecurityException($"User '{user.Username}' has reached their maximum number of concurrent video streams ({user.MaxActiveVideoStreams}).");
-                        }
-                    }
-                }
-            }
-
             await UpdateNowPlayingItem(session, info, libraryItem, true).ConfigureAwait(false);
 
             if (!string.IsNullOrEmpty(session.DeviceId) && info.PlayMethod != PlayMethod.Transcode)


### PR DESCRIPTION
This pull request refactors the logic for enforcing video stream limits, moving it from the `SessionManager` to the `DynamicHlsController`. The changes ensure that stream limit checks are performed specifically during transcoding requests, improving modularity and aligning the logic with its relevant context.

### Refactoring of Video Stream Limit Enforcement:

* Removed the video stream limit check logic from the `OnPlaybackStart` method in `SessionManager.cs`, simplifying the playback start process.
* Added video stream limit checks to the `DynamicHlsController` before starting transcoding, ensuring that user limits are enforced at the appropriate stage.

### Dependency Injection Updates:

* Introduced the `ISessionManager` dependency to `DynamicHlsController` to enable session management functionality for stream limit checks. [[1]](diffhunk://#diff-ab579a24be3882376b30a1f50886a7fdd3e80b5c4b18ec33e20f83ee8caafe66R22) [[2]](diffhunk://#diff-ab579a24be3882376b30a1f50886a7fdd3e80b5c4b18ec33e20f83ee8caafe66R64) [[3]](diffhunk://#diff-ab579a24be3882376b30a1f50886a7fdd3e80b5c4b18ec33e20f83ee8caafe66R80) [[4]](diffhunk://#diff-ab579a24be3882376b30a1f50886a7fdd3e80b5c4b18ec33e20f83ee8caafe66L89-R93) [[5]](diffhunk://#diff-ab579a24be3882376b30a1f50886a7fdd3e80b5c4b18ec33e20f83ee8caafe66R106)